### PR TITLE
feat: wal-flood workload (WAL flood → replication lag → disk-full)

### DIFF
--- a/.claude/skills/project-knowledge/references/architecture.md
+++ b/.claude/skills/project-knowledge/references/architecture.md
@@ -42,6 +42,7 @@ The repo is a Go module (`github.com/lesovsky/noisia`) with one package per work
 ├── forkconns/         [workload: excessive backend forking]
 ├── backendkiller/     [workload: prepared-statement leak → backend OOM → instance restart]
 ├── slotbloat/         [workload: un-consumed physical replication slot pins WAL → pg_wal fills disk → instance PANIC]
+├── walflood/          [workload: --jobs parallel UPDATE-churn workers over disjoint ranges flood WAL → replication lag / disk-full]
 ├── Dockerfile         [multi-stage build → scratch image]
 ├── Makefile           [dep/lint/test/build/docker targets]
 └── .github/workflows/ [CI: default.yml (lint+test), release.yml (test+docker+goreleaser)]

--- a/.claude/skills/project-knowledge/references/patterns.md
+++ b/.claude/skills/project-knowledge/references/patterns.md
@@ -78,6 +78,21 @@ testcontainers starts/stops PostgreSQL automatically; nothing else to set up.
 **File:** `backendkiller/` (incl. `backendkiller_test.go`)
 **Shows:** the "slow / escalating" workload style — one dedicated `db.Connect` connection (not the pool), a single-threaded rate-limited loop (`rate.Inf` for unlimited), a self-report escalation panel emitted from a separate ticker goroutine reading only atomics, and connection-loss climax detection. Also the `sanitize` helper that keeps `Conninfo` out of every log/error line, and setting `application_name=noisia` on a raw `db.Connect` connection (which, unlike the pool, does not set it). First entry of the new-workloads backlog (`docs/BACKLOG.md`).
 
+### Multi-worker fan-out over disjoint ranges (per-worker connection)
+**File:** `walflood/` (incl. `walflood_test.go`)
+**Shows:** the "slow/escalating + self-report" pattern scaled to N concurrent workers driven by the
+global `--jobs` flag. Key lessons: spawn long-lived workers with the **rollbacks** `sync.WaitGroup` +
+goroutine-per-job shape (not the idlexacts/deadlocks guard-channel, which is spawn-on-completion); give
+each worker its **own** `db.Connect` rather than sharing a pool, because `db.NewPostgresDB` never sets
+`max_conns` and the pgxpool default `max(4, NumCPU)` would silently cap real parallelism below `--jobs`
+(and make a "--jobs honored" test flaky on low-CPU hosts) — the per-worker connection also needs a manual
+`SET application_name='noisia'` since `db.Connect` (unlike the pool) does not set it; partition the work
+into disjoint id sub-ranges so workers never serialize on row locks (validate `rows >= jobs` to drop the
+empty-tail edge); share ONE `*atomic.Int64` and judge init-vs-climax on it so one slow worker's early
+error cannot masquerade as a setup failure once any worker has written. The integration test asserts
+`--jobs` is honored via `>= N` `application_name='noisia'` backends in `pg_stat_activity`, independent of
+host CPU.
+
 ### Cleanup of persistent server objects (fresh connection)
 **File:** `slotbloat/` (incl. `slotbloat_test.go`)
 **Shows:** the "slow / escalating" pattern extended to a workload that creates **persistent** server objects (a physical replication slot + a regular table) which must be dropped on exit. Key lesson learned on the stand: a workload's own `db.Connect` connection is **dead at cleanup time** — when the run is stopped via ctx-cancel, pgx closes any connection whose in-flight query was interrupted, so the deferred cleanup must open a **fresh** `db.Connect` on a timeout-bounded `context.Background()` to run the drops (reusing the workload conn fails with `failed to deallocate cached statement(s): conn closed`). Pool-based workloads (e.g. `waitxacts`) get a healthy connection for free; single-`db.Connect` workloads must open one explicitly. Also: seed large tables with one set-based `INSERT ... SELECT generate_series(...)` (not a per-row loop) and bracket a potentially long seed with explicit progress log lines so it doesn't look hung.

--- a/.claude/skills/project-knowledge/references/project.md
+++ b/.claude/skills/project-knowledge/references/project.md
@@ -43,6 +43,7 @@ Each workload is an independent, separately-toggleable generator:
 - **fork connections** — run single short queries each in a fresh connection (excessive backend forking).
 - **backend-killer** — a single session leaks prepared statements (server-side plan-cache growth) until the backend is OOM-killed and the postmaster restarts the whole instance.
 - **slot-bloat** — a single un-consumed physical replication slot pins WAL while UPDATE churn runs over a flat pre-seeded table, so `pg_wal` grows unbounded (checkpoints can't reclaim it) until the disk fills and the instance PANICs; self-reports its own payload bytes, not server WAL state.
+- **wal-flood** — `--jobs` parallel UPDATE-churn workers flood WAL on the primary over disjoint id ranges of one flat seed table (no slot, one connection per worker); reliably drives replication lag and, where recycle/archiving can't keep up, `pg_wal` growth toward disk-full (environment-dependent, not guaranteed). The generation-rate counterpart to slot-bloat's retention; self-reports payload bytes only.
 
 Usable both as a CLI binary and as an importable Go library (each workload package exposes a `Workload` with `NewWorkload` + `Run(ctx)`).
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - `fork connections` - execute single, short query in a dedicated connection (lead to excessive forking of Postgres backends).
 - `backend-killer` - single session leaks prepared statements (plan-cache growth) inflating its backend's memory until OOM-kill restarts the whole instance; a very large `--backend-killer.plan-size` makes each `PREPARE` heavy/slow.
 - `slot-bloat` - a single un-consumed physical replication slot pins WAL so `pg_wal` grows without bound → disk full → instance PANIC; the data never grows and checkpoints keep running, yet the disk still fills.
+- `wal-flood` - many parallel `UPDATE`-churn workers (`--jobs`) flood WAL on the primary by raw write rate, driving replication lag and — when recycle/archiving can't keep up — `pg_wal` growth toward disk-full; the visible-activity counterpart of `slot-bloat` (disk-full here is environment-dependent, not guaranteed).
 - ...see built-in help for more runtime options.
 
 #### Disclaimer
@@ -90,6 +91,7 @@ Running workloads could impact already running workloads produced by other appli
 | tempfiles  | **Yes**: might increase storage utilization and degrade storage performance  |
 | terminate  | **Yes**: already established database connections could be terminated accidentally  |
 | waitxacts  | **Yes**: locks heavy-write tables; this leads to blocking concurrently executed queries  |
+| walflood  | **Yes**: high-rate WAL generation drives replication lag and IO pressure; in a constrained environment `pg_wal` grows toward disk-full and the instance PANICs  |
 
 #### Demo & tuning guides
 
@@ -97,6 +99,7 @@ The escalating workloads each have a dedicated demo and tuning guide covering ho
 
 - [`docs/workloads/backend-killer.md`](docs/workloads/backend-killer.md) — drive a single backend to OOM and an instance restart; cap memory, disable swap, and turn up the plan pressure.
 - [`docs/workloads/slot-bloat.md`](docs/workloads/slot-bloat.md) — fill `pg_wal` with one forgotten replication slot until the disk is full; CLI flags, two stand recipes, and slot-crash recovery.
+- [`docs/workloads/wal-flood.md`](docs/workloads/wal-flood.md) — flood WAL with parallel `UPDATE`-churn workers; the honest env-dependent contract, the disk-full conditions, demo parameters, and how it differs from `slot-bloat`.
 
 #### Contribution
 - PR's are welcome.

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lesovsky/noisia/tempfiles"
 	"github.com/lesovsky/noisia/terminate"
 	"github.com/lesovsky/noisia/waitxacts"
+	"github.com/lesovsky/noisia/walflood"
 	"sync"
 	"time"
 )
@@ -57,6 +58,11 @@ type config struct {
 	slotBloatPayloadBytes       int
 	slotBloatReportInterval     time.Duration
 	slotBloatKeepSlot           bool
+	walFlood                    bool
+	walFloodRate                float64
+	walFloodRows                int
+	walFloodPayloadBytes        int
+	walFloodReportInterval      time.Duration
 }
 
 func runApplication(ctx context.Context, c config, log log.Logger) error {
@@ -180,6 +186,18 @@ func runApplication(ctx context.Context, c config, log log.Logger) error {
 			err := startSlotBloatWorkload(ctx, c, log)
 			if err != nil {
 				log.Errorf("slot-bloat workload failed: %s", err)
+			}
+			wg.Done()
+		}()
+	}
+
+	if c.walFlood {
+		log.Info("start wal-flood workload")
+		wg.Add(1)
+		go func() {
+			err := startWalFloodWorkload(ctx, c, log)
+			if err != nil {
+				log.Errorf("wal-flood workload failed: %s", err)
 			}
 			wg.Done()
 		}()
@@ -326,6 +344,24 @@ func startSlotBloatWorkload(ctx context.Context, c config, logger log.Logger) er
 			PayloadBytes:   c.slotBloatPayloadBytes,
 			ReportInterval: c.slotBloatReportInterval,
 			KeepSlot:       c.slotBloatKeepSlot,
+		}, logger,
+	)
+	if err != nil {
+		return err
+	}
+
+	return workload.Run(ctx)
+}
+
+func startWalFloodWorkload(ctx context.Context, c config, logger log.Logger) error {
+	workload, err := walflood.NewWorkload(
+		walflood.Config{
+			Conninfo:       c.postgresConninfo,
+			Rate:           c.walFloodRate,
+			Rows:           c.walFloodRows,
+			PayloadBytes:   c.walFloodPayloadBytes,
+			ReportInterval: c.walFloodReportInterval,
+			Jobs:           c.jobs,
 		}, logger,
 	)
 	if err != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -57,6 +57,11 @@ func main() {
 		slotBloatPayloadBytes       = kingpin.Flag("slot-bloat.payload-bytes", "Payload bytes per row/UPDATE (K)").Default("8192").Envar("NOISIA_SLOT_BLOAT_PAYLOAD_BYTES").Int()
 		slotBloatReportInterval     = kingpin.Flag("slot-bloat.report-interval", "Escalation panel print cadence").Default("1s").Envar("NOISIA_SLOT_BLOAT_REPORT_INTERVAL").Duration()
 		slotBloatKeepSlot           = kingpin.Flag("slot-bloat.keep-slot", "Keep slot and table on graceful exit").Default("false").Envar("NOISIA_SLOT_BLOAT_KEEP_SLOT").Bool()
+		walFlood                    = kingpin.Flag("wal-flood", "Run wal-flood workload").Default("false").Envar("NOISIA_WAL_FLOOD").Bool()
+		walFloodRate                = kingpin.Flag("wal-flood.rate", "UPDATE rate per second per worker; 0 means unlimited").Default("0").Envar("NOISIA_WAL_FLOOD_RATE").Float64()
+		walFloodRows                = kingpin.Flag("wal-flood.rows", "Number of seed rows (N)").Default("1000").Envar("NOISIA_WAL_FLOOD_ROWS").Int()
+		walFloodPayloadBytes        = kingpin.Flag("wal-flood.payload-bytes", "Payload bytes per UPDATE (K)").Default("8192").Envar("NOISIA_WAL_FLOOD_PAYLOAD_BYTES").Int()
+		walFloodReportInterval      = kingpin.Flag("wal-flood.report-interval", "Escalation panel print cadence").Default("1s").Envar("NOISIA_WAL_FLOOD_REPORT_INTERVAL").Duration()
 	)
 	kingpin.Parse()
 
@@ -107,6 +112,11 @@ func main() {
 		slotBloatPayloadBytes:       *slotBloatPayloadBytes,
 		slotBloatReportInterval:     *slotBloatReportInterval,
 		slotBloatKeepSlot:           *slotBloatKeepSlot,
+		walFlood:                    *walFlood,
+		walFloodRate:                *walFloodRate,
+		walFloodRows:                *walFloodRows,
+		walFloodPayloadBytes:        *walFloodPayloadBytes,
+		walFloodReportInterval:      *walFloodReportInterval,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -73,7 +73,11 @@ Each entry below is sized to be expanded into a user-spec.
 - **Self-report:** WAL bytes generated, transactions/s, uptime.
 - **Symptoms to teach:** WAL volume spikes, archiver/replication pressure, IO saturation.
 - **Remediation discussion:** WAL tuning, batching, checkpoint configuration.
-- **Notes:** may merge with `checkpoint-storm` below.
+- **Notes:** kept separate from `checkpoint-storm` (different mechanism: fsync pressure vs raw WAL
+  volume); FPI/checkpoint-storm amplification is shown only as an observable side effect, not a mode.
+- **Status:** implemented (003-feat-wal-flood). `--jobs` parallel UPDATE-churn over disjoint ranges,
+  per-worker connection, no slot; self-reports `payload-written`. Verified by unit + testcontainers
+  integration tests; real disk-full is a manual stand demo (env-dependent), not CI.
 
 ## Priority 3 — CPU → 100%
 

--- a/docs/workloads/wal-flood.md
+++ b/docs/workloads/wal-flood.md
@@ -1,0 +1,118 @@
+# wal-flood — demo & tuning guide
+
+How to drive a `wal-flood` demo: CLI flags, the honest self-report caveat, the environment conditions that turn pressure into disk-full, recommended demo parameters, and how it differs from `slot-bloat`.
+
+`wal-flood` seeds one fixed-size table and fans out `--jobs` long-lived `UPDATE`-churn workers over
+**disjoint** id ranges of it, with **no replication slot**. The churn generates WAL as fast as the
+workers (and the server) allow. Unlike `slot-bloat`, which pins WAL with a forgotten slot while the
+instance is idle, `wal-flood` produces WAL by raw write rate — the visible-activity counterpart of the
+same disk-full lesson. Each worker owns its own connection, so the aggregate WAL rate scales with
+`--jobs` and does not collapse on row-lock contention.
+
+## The honest contract — what is and isn't guaranteed
+
+`wal-flood` **reliably** produces sustained WAL pressure, and — when a standby is attached — **replication
+lag**, because the primary generates WAL faster than the replica can apply it. Escalation all the way to
+a disk-full PANIC is **environment-dependent, not a guarantee**: unlike `slot-bloat` (where a pinned slot
+makes `pg_wal` growth deterministic), a pure generation-rate flood **plateaus** once checkpoints recycle
+WAL as fast as it is written. On capable I/O you will see high WAL throughput and replica lag, but the
+disk will not fill. That is expected behaviour, not a bug.
+
+### Conditions for a real disk-full demo
+
+To make the flood actually fill `pg_wal`, the environment must prevent WAL from being recycled or drained
+as fast as it is generated. Arrange at least one of:
+
+- **Slow storage / constrained I/O** — the checkpointer cannot flush dirty buffers fast enough, so WAL
+  cannot be recycled and `pg_wal` grows.
+- **A small `pg_wal` volume** — put `pg_wal` on its own small filesystem (a few GB) so it fills quickly.
+- **A lagging or broken `archive_command`** — with `archive_mode=on` and an `archive_command` that is slow
+  or failing, WAL segments are retained until archived; `.ready` files pile up and `pg_wal` grows.
+- **A lagging or disconnected replica with WAL retention** (`wal_keep_size` / a slot held elsewhere) — the
+  primary retains WAL the standby has not consumed.
+
+If none of these hold, the workload demonstrates WAL throughput and replica lag but will not reach
+disk-full — read the panel and replica lag instead.
+
+## CLI flags
+
+| Flag | Envar | Type | Default | Purpose |
+|------|-------|------|---------|---------|
+| `--wal-flood` | `NOISIA_WAL_FLOOD` | bool | `false` | Enable the workload |
+| `--wal-flood.rate` | `NOISIA_WAL_FLOOD_RATE` | float64 | `0` | UPDATEs/sec **per worker**; `0` = unbounded (`rate.Inf`) |
+| `--wal-flood.rows` | `NOISIA_WAL_FLOOD_ROWS` | int | `1000` | Total rows seeded into the table, split into `--jobs` disjoint id ranges |
+| `--wal-flood.payload-bytes` | `NOISIA_WAL_FLOOD_PAYLOAD_BYTES` | int | `8192` | Payload size (bytes) per UPDATE |
+| `--wal-flood.report-interval` | `NOISIA_WAL_FLOOD_REPORT_INTERVAL` | duration | `1s` | How often the escalation panel is printed |
+
+The number of churn workers comes from the **global** `--jobs` flag (there is no per-workload jobs flag).
+`--wal-flood.rows` must be `>= --jobs` so every worker owns at least one row; the aggregate rate is roughly
+`--jobs × --wal-flood.rate` (or unbounded when `rate=0`). The workload logs `wal-flood: seeding …` while it
+seeds, then `seeding done, starting N churn workers`.
+
+### Connections and privileges
+
+The workload uses **`--jobs` + 2** connections: one per worker, plus one for seeding and one for cleanup.
+At high `--jobs` make sure the target's `max_connections` (and any pooler limit) leaves room for them.
+
+It needs only ordinary write access: `CREATE` on a schema to seed its table and `UPDATE` on it.
+**No `REPLICATION` privilege is required** (unlike `slot-bloat`) — `wal-flood` creates no slot.
+
+## Honest self-report caveat
+
+Every `report-interval` the escalation panel prints a line such as:
+
+```
+wal-flood: payload-written=4.2GB rate=180MB/s elapsed=3m12s
+```
+
+`payload-written` is labelled honestly: it is the **application bytes the workers themselves pushed**
+(successful UPDATEs × `payload-bytes`), **not** the size of `pg_wal` on disk. The real `pg_wal` is larger —
+full-page writes (FPI) after each checkpoint, WAL-record alignment, and autovacuum-generated WAL all add to
+it. The self-report never polls server state, so the panel stays truthful even when the instance is already
+down at the moment of a catastrophe. Replication lag is **not** reported by noisia — observe it on the
+server with pgcenter / pgSCV (`pg_stat_replication`).
+
+## Recommended parameters for a visible demo
+
+The defaults (`rows=1000`, `payload-bytes=8192` ≈ an 8 MB seed table, `jobs=1`) are deliberately modest and
+may not produce a visible effect on fast hardware. For a demonstration, turn up the pressure:
+
+- **Parallelism:** `--jobs=8` (or as many as the host and `max_connections` allow) so multiple backends
+  write WAL concurrently.
+- **Payload:** `--wal-flood.payload-bytes=65536` (64 KB) so each UPDATE writes more WAL.
+- **Rows:** `--wal-flood.rows=10000` so writes spread across many heap pages (and `rows >= jobs`).
+- **Rate:** leave `--wal-flood.rate=0` (unbounded) for maximum pressure.
+
+```
+noisia --wal-flood --jobs=8 \
+  --wal-flood.payload-bytes=65536 --wal-flood.rows=10000 \
+  --conninfo="host=127.0.0.1 user=postgres dbname=postgres" --duration=10m
+```
+
+Watch the WAL rate and replica lag in pgcenter / pgSCV (`pg_stat_replication`), and `pg_wal` size via
+`df -h` on a constrained stand. Note the full-page-write spike right after each checkpoint — that
+amplification is a natural side effect of churning a heap table, visible as a jump in the WAL rate.
+
+> A real disk-full cannot be reproduced in CI — it is a stand demo verified by hand, and only on a
+> standalone/on-prem instance. Managed PostgreSQL (RDS / Cloud SQL / Supabase) is out of scope: recovery
+> needs filesystem access that managed providers do not grant.
+
+## wal-flood vs slot-bloat
+
+Both fill `pg_wal`, but the mechanism — and the lesson — differ:
+
+- **`slot-bloat` — retention, deterministic.** A forgotten replication slot pins WAL so checkpoints can
+  never recycle it; `pg_wal` grows without bound regardless of write rate, while the data stays flat. The
+  disk fills with **no visible activity** — the counter-intuitive case.
+- **`wal-flood` — generation rate, environment-dependent.** Many fast writes generate WAL faster than it
+  can be recycled/archived/replicated; the symptom is a WAL-rate spike, replication lag and archiver
+  pressure, and disk-full only when the environment cannot keep up. The cause is **obvious** — the server
+  is writing a lot.
+
+## Remediation discussion
+
+Topics this demo sets up for a junior DBA: WAL tuning (`max_wal_size`, `checkpoint_completion_target`,
+`min_wal_size`), checkpoint configuration and the cost of frequent checkpoints (FPI amplification),
+batching writes to reduce WAL volume, sizing the `pg_wal` volume and storage throughput, monitoring
+replication lag (`pg_stat_replication`) and archiver health, and capping retention with
+`max_slot_wal_keep_size` / `wal_keep_size` where slots or standbys are involved.

--- a/docs/workloads/wal-flood.md
+++ b/docs/workloads/wal-flood.md
@@ -80,7 +80,9 @@ may not produce a visible effect on fast hardware. For a demonstration, turn up 
 - **Parallelism:** `--jobs=8` (or as many as the host and `max_connections` allow) so multiple backends
   write WAL concurrently.
 - **Payload:** `--wal-flood.payload-bytes=65536` (64 KB) so each UPDATE writes more WAL.
-- **Rows:** `--wal-flood.rows=10000` so writes spread across many heap pages (and `rows >= jobs`).
+- **Rows:** `--wal-flood.rows=10000` so writes spread across many heap pages (and `rows >= jobs`). A
+  small `rows` with a large `payload-bytes` packs many ids onto the same heap page, where concurrent
+  UPDATEs contend on the page lock and the WAL rate drops — keep `rows` generous.
 - **Rate:** leave `--wal-flood.rate=0` (unbounded) for maximum pressure.
 
 ```

--- a/walflood/main_test.go
+++ b/walflood/main_test.go
@@ -1,0 +1,10 @@
+package walflood
+
+import (
+	"os"
+	"testing"
+
+	"github.com/lesovsky/noisia/internal/dbtest"
+)
+
+func TestMain(m *testing.M) { os.Exit(dbtest.RunMain(m)) }

--- a/walflood/walflood.go
+++ b/walflood/walflood.go
@@ -26,10 +26,14 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/lesovsky/noisia"
+	"github.com/lesovsky/noisia/db"
 	"github.com/lesovsky/noisia/log"
+	"golang.org/x/time/rate"
 )
 
 // Config defines configuration settings for wal-flood workload.
@@ -102,12 +106,258 @@ func NewWorkload(config Config, logger log.Logger) (noisia.Workload, error) {
 	return &workload{config, logger}, nil
 }
 
-// Run drives the WAL flood. The seed, the Jobs-way disjoint-range churn fan-out, the
-// reporter and the cleanup are implemented in Task 02.
+// Run opens a dedicated connection to seed one fixed-heap table, then fans out Jobs
+// long-lived churn workers over disjoint id ranges while a ticker reports progress.
+// Each worker owns its own connection (no shared pool, so the pool default max_conns
+// cannot cap parallelism below --jobs). The seed table is dropped in a defer on a
+// fresh context.Background() (ctx is already cancelled at exit).
 func (w *workload) Run(ctx context.Context) error {
-	// TODO(task-02): seed table, spawn Jobs churn workers over disjoint ranges,
-	// run the reporter ticker, and drop the seed table on a fresh connection.
+	conn, err := db.Connect(ctx, w.config.Conninfo)
+	if err != nil {
+		// Never echo the raw error: it may carry DSN fragments (e.g. password=…).
+		return fmt.Errorf("connect to target failed: %s", sanitize(err))
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Attribute the seeding backend in pg_stat_activity. db.Connect (unlike the pool
+	// path) does not set application_name, so set it locally here.
+	_, _, err = conn.Exec(ctx, "SET application_name = 'noisia'")
+	if err != nil {
+		return fmt.Errorf("set application_name failed: %s", sanitize(err))
+	}
+
+	// Build the per-run table name once. The suffix is restricted to [a-z0-9], which
+	// alone makes the identifier injection-safe; double-quoting is belt-and-suspenders.
+	// The identifier (which cannot be a bind parameter) is reused verbatim in
+	// CREATE/UPDATE/DROP; payload and id are bind args.
+	tableIdent := "\"noisia_walflood_" + randomSuffix(8) + "\""
+
+	// Cleanup is registered right after a successful connect so the table is dropped
+	// even if seeding fails. It runs on a fresh context.Background() because ctx is
+	// already cancelled at exit and a drop on a cancelled ctx would fail (ADR-002-2).
+	defer w.cleanup(tableIdent)
+
+	// Seed the fixed row set churned in place. Seeding can take a while for large
+	// rows/payload, and the reporter starts only after it, so emit explicit feedback.
+	w.logger.Infof("wal-flood: seeding %d rows (~%s), this may take a while...", w.config.Rows, formatBytes(int64(w.config.Rows)*int64(w.config.PayloadBytes)))
+	err = prepare(ctx, conn, tableIdent, w.config.Rows, w.config.PayloadBytes)
+	if err != nil {
+		// A clean ctx stop must not be reported as a failure.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("seed table failed: %s", sanitize(err))
+	}
+	w.logger.Infof("wal-flood: seeding done, starting %d churn workers", w.config.Jobs)
+
+	// counter holds the total payload bytes successfully written by all workers
+	// (successful UPDATEs × K). It is shared across workers and read by the reporter,
+	// which must never touch a (not concurrency-safe) Conn.
+	var counter atomic.Int64
+
+	start := time.Now()
+	tickerDone := make(chan struct{})
+	var reporterWg sync.WaitGroup
+	reporterWg.Add(1)
+	go func() {
+		defer reporterWg.Done()
+		w.runReporter(ctx, tickerDone, start, &counter)
+	}()
+
+	// Fan out exactly Jobs long-lived workers, each over its own disjoint id range.
+	ranges := partition(w.config.Rows, w.config.Jobs)
+	updateSQL := fmt.Sprintf("UPDATE %s SET payload = $1 WHERE id = $2", tableIdent)
+
+	var wg sync.WaitGroup
+	errs := make([]error, len(ranges))
+	wg.Add(len(ranges))
+	for i, r := range ranges {
+		go func(idx, lo, hi int) {
+			defer wg.Done()
+			errs[idx] = w.runWorker(ctx, updateSQL, lo, hi, &counter)
+		}(i, r[0], r[1])
+	}
+	wg.Wait()
+
+	close(tickerDone)
+	reporterWg.Wait()
+
+	// Surface the first init error (a real setup defect — e.g. exhausted connections)
+	// reported by any worker; a clean stop or a climax leaves all errs nil.
+	for _, e := range errs {
+		if e != nil {
+			return e
+		}
+	}
+
 	return nil
+}
+
+// runWorker opens its OWN dedicated connection and drives the churn loop over the
+// [lo, hi] id sub-range. A per-worker connection guarantees Jobs concurrent in-flight
+// UPDATEs regardless of any pool sizing. Every connection error passes through
+// sanitize so a pgx error can never leak a DSN fragment.
+func (w *workload) runWorker(ctx context.Context, updateSQL string, lo, hi int, counter *atomic.Int64) error {
+	conn, err := db.Connect(ctx, w.config.Conninfo)
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil
+		}
+		return fmt.Errorf("worker connect failed: %s", sanitize(err))
+	}
+	defer func() { _ = conn.Close() }()
+
+	// db.Connect does not set application_name; do it best-effort so the worker is
+	// attributable in pg_stat_activity. A failed SET must not abort the worker, but
+	// its error still passes through sanitize so the DSN is never logged.
+	if _, _, serr := conn.Exec(ctx, "SET application_name = 'noisia'"); serr != nil {
+		w.logger.Warnf("wal-flood: set application_name failed: %s", sanitize(serr))
+	}
+
+	return runChurn(ctx, conn, w.logger, w.config, updateSQL, lo, hi, counter)
+}
+
+// runChurn is one worker's rate-limited UPDATE loop. It owns its Conn and cycles id
+// only within its disjoint [lo, hi] sub-range, adding K to the SHARED counter for
+// every successful UPDATE.
+//
+// Returns nil on a clean ctx stop. On a connection loss after at least one successful
+// UPDATE anywhere (shared counter>0) while the context is still live, it logs the
+// climax line and returns nil. The first Exec error while the shared counter is still
+// 0 is returned as an init error, so a broken setup cannot masquerade as a successful
+// disk-full event — and one worker's early error cannot do so either once any worker
+// has written (Decision 3).
+func runChurn(ctx context.Context, conn db.Conn, logger log.Logger, config Config, updateSQL string, lo, hi int, counter *atomic.Int64) error {
+	lim := rate.Limit(config.Rate)
+	if config.Rate == 0 {
+		lim = rate.Inf
+	}
+	limiter := rate.NewLimiter(lim, 1)
+
+	payload := make([]byte, config.PayloadBytes)
+	id := lo - 1
+
+	for {
+		if limiter.Allow() {
+			// Cycle id over the worker's disjoint range [lo, hi].
+			id++
+			if id > hi {
+				id = lo
+			}
+
+			_, _, err := conn.Exec(ctx, updateSQL, payload, id)
+			if err != nil {
+				// A clean ctx stop must not be reported as a failure.
+				if ctx.Err() != nil {
+					return nil
+				}
+
+				if counter.Load() > 0 {
+					logger.Infof("wal-flood: connection lost — target likely disk-full/restarted")
+					return nil
+				}
+
+				// First Exec failed with no prior success anywhere: setup defect.
+				return fmt.Errorf("churn update failed: %s", sanitize(err))
+			}
+
+			counter.Add(int64(config.PayloadBytes))
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+	}
+}
+
+// runReporter prints the escalation panel every ReportInterval, reading only the
+// shared atomic payload-bytes counter. It never queries a Conn.
+func (w *workload) runReporter(ctx context.Context, done <-chan struct{}, start time.Time, counter *atomic.Int64) {
+	ticker := time.NewTicker(w.config.ReportInterval)
+	defer ticker.Stop()
+
+	var prev int64
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-done:
+			return
+		case <-ticker.C:
+			cur := counter.Load()
+			elapsed := time.Since(start)
+			rate := int64(float64(cur-prev) / w.config.ReportInterval.Seconds())
+			prev = cur
+
+			w.logger.Infof("wal-flood: payload-written=%s rate=%s/s elapsed=%s", formatBytes(cur), formatBytes(rate), elapsed.Truncate(time.Second))
+		}
+	}
+}
+
+// prepare creates the seed table and inserts N rows of K-byte payload in a single
+// transaction. The heap is deliberately fixed: the churn loop UPDATEs these rows in
+// place, so only WAL grows, not the table.
+func prepare(ctx context.Context, conn db.Conn, tableIdent string, rows, payloadBytes int) error {
+	tx, err := conn.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	_, _, err = tx.Exec(ctx, fmt.Sprintf("CREATE TABLE %s (id int PRIMARY KEY, payload bytea)", tableIdent))
+	if err != nil {
+		return err
+	}
+
+	// The payload content is intentionally a fixed zero-filled buffer: WAL is
+	// generated by the UPDATE regardless of byte equality, so the value is irrelevant.
+	payload := make([]byte, payloadBytes)
+	// Seed in a single set-based statement: one server-side round-trip instead of N
+	// network round-trips, which matters for large N over a remote link.
+	insertSQL := fmt.Sprintf("INSERT INTO %s (id, payload) SELECT g, $1 FROM generate_series(1, $2) AS g", tableIdent)
+	_, _, err = tx.Exec(ctx, insertSQL, payload, rows)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// cleanup drops the seed table on a fresh context.Background() (ctx is already
+// cancelled at exit), bounded by a short timeout so a hung (not dead) target cannot
+// block Run's return forever. It opens its OWN fresh connection rather than reusing a
+// worker conn: a Ctrl+C landing mid-UPDATE aborts the in-flight query and poisons that
+// conn, so a DROP over it would fail and orphan the table (ADR-002-2). Any failure is
+// logged via Warnf with the table name so nothing is silently orphaned. Every error
+// passes through sanitize.
+func (w *workload) cleanup(tableIdent string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Open a fresh connection: a worker conn may be dead after a mid-UPDATE cancel.
+	conn, err := db.Connect(ctx, w.config.Conninfo)
+	if err != nil {
+		// The target may be unreachable (e.g. in PANIC at real disk-full). Nothing was
+		// dropped — say so honestly so the table is not silently assumed gone.
+		w.logger.Warnf("wal-flood: cleanup failed for table %s: %s — drop manually", tableIdent, sanitize(err))
+		return
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Attribute the cleanup DROP in pg_stat_activity. Best-effort: the drop and its
+	// honest logging are what matter, so a failed SET must not abort cleanup — ignore
+	// the error and proceed. Conninfo is never logged.
+	_, _, _ = conn.Exec(ctx, "SET application_name = 'noisia'")
+
+	_, _, err = conn.Exec(ctx, fmt.Sprintf("DROP TABLE IF EXISTS %s", tableIdent))
+	if err != nil {
+		w.logger.Warnf("wal-flood: cleanup failed for table %s: %s — drop manually", tableIdent, sanitize(err))
+		return
+	}
+
+	w.logger.Infof("wal-flood: table dropped")
 }
 
 // partition splits the id space 1..rows into jobs contiguous, non-overlapping

--- a/walflood/walflood.go
+++ b/walflood/walflood.go
@@ -1,0 +1,177 @@
+// Copyright 2021 The Noisia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package walflood defines implementation of workload which deliberately drives a
+// high rate of WAL generation on a primary PostgreSQL instance.
+//
+// Unlike slot-bloat (which pins WAL with a forgotten replication slot while the
+// instance stays idle), wal-flood has NO replication slot: it seeds one regular
+// table with N rows of K-byte payload and fans out --jobs long-lived, rate-limited
+// UPDATE-churn workers over DISJOINT id sub-ranges of that single table. Each worker
+// owns its own connection and a contiguous, non-overlapping slice of the row set, so
+// writers never serialize on row locks and the aggregate WAL rate scales with --jobs.
+//
+// The workload self-reports honestly: it keeps an in-process counter of the
+// application payload bytes it has written (count × K) and prints an escalation
+// panel every report-interval, labeled payload-written. It never polls server WAL
+// state, so the log stays truthful even when the target becomes unreachable at the
+// moment of catastrophe. Escalation to disk-full is environment-dependent, not a
+// guarantee: on capable I/O the WAL rate plateaus instead of filling the disk.
+// Workload duration is controlled by a context created outside and passed to Run.
+package walflood
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"strings"
+	"time"
+
+	"github.com/lesovsky/noisia"
+	"github.com/lesovsky/noisia/log"
+)
+
+// Config defines configuration settings for wal-flood workload.
+type Config struct {
+	// Conninfo defines connection string used for connecting to Postgres.
+	// It is a secret and must never be logged.
+	Conninfo string
+	// Rate defines UPDATE statements rate per second PER worker; 0 means unlimited (rate.Inf).
+	Rate float64
+	// Rows defines the total number of seed rows, partitioned into Jobs disjoint
+	// id ranges and churned in place (>= 1, and >= Jobs).
+	Rows int
+	// PayloadBytes defines the payload size in bytes per UPDATE (>= 1).
+	PayloadBytes int
+	// ReportInterval defines the escalation panel print cadence.
+	ReportInterval time.Duration
+	// Jobs defines how many concurrent churn workers to run, taken from the global
+	// --jobs flag (>= 1). Each worker owns one disjoint id sub-range.
+	Jobs uint16
+}
+
+// validate method checks workload configuration settings.
+func (c Config) validate() error {
+	if c.Conninfo == "" {
+		return fmt.Errorf("conninfo must not be empty")
+	}
+
+	if c.Rate < 0 {
+		return fmt.Errorf("rate must not be negative")
+	}
+
+	if c.Rows < 1 {
+		return fmt.Errorf("rows must be greater than zero")
+	}
+
+	if c.PayloadBytes < 1 {
+		return fmt.Errorf("payload bytes must be greater than zero")
+	}
+
+	if c.ReportInterval <= 0 {
+		return fmt.Errorf("report interval must be positive")
+	}
+
+	if c.Jobs < 1 {
+		return fmt.Errorf("jobs must be greater than zero")
+	}
+
+	// Partition rule (Decision 2): every worker must own at least one row, so the
+	// row set cannot be smaller than the number of workers.
+	if c.Rows < int(c.Jobs) {
+		return fmt.Errorf("rows must not be less than jobs")
+	}
+
+	return nil
+}
+
+// workload implements noisia.Workload interface.
+type workload struct {
+	config Config
+	logger log.Logger
+}
+
+// NewWorkload creates a new workload with specified config.
+func NewWorkload(config Config, logger log.Logger) (noisia.Workload, error) {
+	err := config.validate()
+	if err != nil {
+		return nil, err
+	}
+
+	return &workload{config, logger}, nil
+}
+
+// Run drives the WAL flood. The seed, the Jobs-way disjoint-range churn fan-out, the
+// reporter and the cleanup are implemented in Task 02.
+func (w *workload) Run(ctx context.Context) error {
+	// TODO(task-02): seed table, spawn Jobs churn workers over disjoint ranges,
+	// run the reporter ticker, and drop the seed table on a fresh connection.
+	return nil
+}
+
+// partition splits the id space 1..rows into jobs contiguous, non-overlapping
+// sub-ranges and returns, for each worker, an inclusive [lo, hi] pair. Worker w
+// (0-based) owns [w*rows/jobs + 1 .. (w+1)*rows/jobs] (Decision 2). The integer
+// division spreads any remainder into the tail ranges with no gap or overlap.
+// Precondition: rows >= jobs (enforced by Config.validate), so no range is empty.
+func partition(rows int, jobs uint16) [][2]int {
+	j := int(jobs)
+	ranges := make([][2]int, 0, j)
+	for w := 0; w < j; w++ {
+		lo := w*rows/j + 1
+		hi := (w + 1) * rows / j
+		ranges = append(ranges, [2]int{lo, hi})
+	}
+	return ranges
+}
+
+// randomSuffix returns a random string of length n drawn from [a-z0-9]. The charset
+// guarantees an injection-safe SQL identifier, and a per-run suffix keeps reruns
+// from colliding on the seed table name.
+func randomSuffix(n int) string {
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}
+
+// sanitize returns an error message stripped of any conninfo fragment that could
+// leak the DSN (e.g. a password). It keeps only the leading part of a pgx error
+// up to the first occurrence of a conninfo-like token.
+func sanitize(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	msg := err.Error()
+	for _, tok := range []string{"password=", "host=", "user=", "dbname=", "database=", "sslmode=", "://"} {
+		if idx := strings.Index(msg, tok); idx >= 0 {
+			return "connection error (details suppressed)"
+		}
+	}
+
+	return msg
+}
+
+// formatBytes renders a byte count as a human-readable string using binary units
+// (base 1024): bytes below 1024 stay as "<n>B"; larger values are scaled to the
+// largest fitting unit (KB/MB/GB) with one fractional digit, e.g. "4.2GB".
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%dB", n)
+	}
+
+	// The unit ladder caps at GB on purpose: the workload's payload counter never
+	// reaches terabytes, so values >= 1 TB render as a large GB number, not TB.
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit && exp < 2; v /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f%cB", float64(n)/float64(div), "KMG"[exp])
+}

--- a/walflood/walflood_test.go
+++ b/walflood/walflood_test.go
@@ -5,11 +5,17 @@
 package walflood
 
 import (
+	"context"
 	"fmt"
 	"regexp"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/lesovsky/noisia/db"
+	"github.com/lesovsky/noisia/log"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -140,4 +146,225 @@ func Test_formatBytes(t *testing.T) {
 	for _, tc := range testcases {
 		assert.Equal(t, tc.want, formatBytes(tc.n))
 	}
+}
+
+// captureLogger is a log.Logger test double that records every Infof line so a test
+// can assert the escalation-panel shape without touching real logging output.
+type captureLogger struct {
+	mu        sync.Mutex
+	infoLines []string
+}
+
+func (l *captureLogger) Info(msg string) {}
+func (l *captureLogger) Infof(format string, v ...interface{}) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.infoLines = append(l.infoLines, fmt.Sprintf(format, v...))
+}
+func (l *captureLogger) Warn(msg string)                        {}
+func (l *captureLogger) Warnf(format string, v ...interface{})  {}
+func (l *captureLogger) Error(msg string)                       {}
+func (l *captureLogger) Errorf(format string, v ...interface{}) {}
+
+func (l *captureLogger) lines() []string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	out := make([]string, len(l.infoLines))
+	copy(out, l.infoLines)
+	return out
+}
+
+// fakeConn is a minimal db.Conn used to exercise the churn init-error / climax /
+// ctx.Done branches without a real database. Only Exec is invoked.
+type fakeConn struct {
+	execErr      error // returned once execOKBefore successful Execs have happened
+	execOKBefore int   // number of successful Execs before execErr is returned
+	mu           sync.Mutex
+	calls        int
+}
+
+func (f *fakeConn) Begin(ctx context.Context) (db.Tx, error) { panic("not implemented") }
+func (f *fakeConn) Exec(ctx context.Context, sql string, args ...interface{}) (int64, string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	if f.calls > f.execOKBefore {
+		return 0, "", f.execErr
+	}
+	return 0, "UPDATE", nil
+}
+func (f *fakeConn) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	panic("not implemented")
+}
+func (f *fakeConn) Close() error { return nil }
+
+func Test_runChurn_firstExecError(t *testing.T) {
+	// The first Exec error with the shared counter still at 0 is a setup defect and is
+	// returned as an init error, never masquerading as a climax.
+	conn := &fakeConn{execErr: fmt.Errorf("permission denied"), execOKBefore: 0}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var counter atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, Rows: 5, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 1}
+
+	err := runChurn(ctx, conn, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 5, &counter)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), counter.Load())
+}
+
+func Test_runChurn_climaxAfterSuccess(t *testing.T) {
+	// An Exec error under a live ctx with counter>0 is the climax — runChurn logs the
+	// climax line and returns nil.
+	conn := &fakeConn{execErr: fmt.Errorf("connection reset by peer"), execOKBefore: 3}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var counter atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, Rows: 5, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 1}
+
+	err := runChurn(ctx, conn, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 5, &counter)
+	assert.NoError(t, err)
+	// 3 successful UPDATEs × 8 bytes.
+	assert.Equal(t, int64(24), counter.Load())
+}
+
+func Test_runChurn_ctxDoneClean(t *testing.T) {
+	// A cancelled ctx must yield a clean return nil — the error is not masked into a failure.
+	conn := &fakeConn{execErr: fmt.Errorf("context canceled"), execOKBefore: 0}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var counter atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, Rows: 5, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 1}
+
+	err := runChurn(ctx, conn, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 5, &counter)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), counter.Load())
+}
+
+func Test_runChurn_twoWorkersConcurrentFirstFailure(t *testing.T) {
+	// Two workers each fail their very first Exec before any success anywhere (shared
+	// counter == 0) => both return init errors (the shared-counter aggregation rule).
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var counter atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, Rows: 4, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 2}
+	logger := log.NewDefaultLogger("error")
+	conn1 := &fakeConn{execErr: fmt.Errorf("permission denied"), execOKBefore: 0}
+	conn2 := &fakeConn{execErr: fmt.Errorf("permission denied"), execOKBefore: 0}
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		errs[0] = runChurn(ctx, conn1, logger, config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 2, &counter)
+	}()
+	go func() {
+		defer wg.Done()
+		errs[1] = runChurn(ctx, conn2, logger, config, "UPDATE t SET payload=$1 WHERE id=$2", 3, 4, &counter)
+	}()
+	wg.Wait()
+
+	assert.Error(t, errs[0])
+	assert.Error(t, errs[1])
+	assert.Equal(t, int64(0), counter.Load())
+}
+
+func Test_runChurn_churnsWithinRange(t *testing.T) {
+	// A worker must only UPDATE ids inside its disjoint [lo, hi] sub-range (the
+	// anti-self-defeat guarantee), cycling within the range.
+	rec := &recordingConn{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+
+	var counter atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, Rows: 10, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 2}
+
+	// Worker owns ids 6..10.
+	_ = runChurn(ctx, rec, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 6, 10, &counter)
+
+	ids := rec.seenIDs()
+	assert.NotEmpty(t, ids, "worker must have issued at least one UPDATE")
+	for id := range ids {
+		assert.GreaterOrEqual(t, id, 6, "id must not fall below the worker's range")
+		assert.LessOrEqual(t, id, 10, "id must not exceed the worker's range")
+	}
+}
+
+// recordingConn is a db.Conn double that records the id bind argument of every UPDATE
+// so a test can assert a worker stays within its disjoint range.
+type recordingConn struct {
+	mu  sync.Mutex
+	ids map[int]struct{}
+}
+
+func (c *recordingConn) Begin(ctx context.Context) (db.Tx, error) { panic("not implemented") }
+func (c *recordingConn) Exec(ctx context.Context, sql string, args ...interface{}) (int64, string, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.ids == nil {
+		c.ids = make(map[int]struct{})
+	}
+	if len(args) == 2 {
+		if id, ok := args[1].(int); ok {
+			c.ids[id] = struct{}{}
+		}
+	}
+	return 0, "UPDATE", nil
+}
+func (c *recordingConn) Query(ctx context.Context, sql string, args ...interface{}) (pgx.Rows, error) {
+	panic("not implemented")
+}
+func (c *recordingConn) Close() error { return nil }
+
+func (c *recordingConn) seenIDs() map[int]struct{} {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make(map[int]struct{}, len(c.ids))
+	for k := range c.ids {
+		out[k] = struct{}{}
+	}
+	return out
+}
+
+func Test_runReporter(t *testing.T) {
+	// runReporter prints the escalation panel each ReportInterval, reading only the
+	// atomic counter. Drive it for a tick against a controlled counter and assert the
+	// panel shape, human-readable formatting (formatBytes) and the counter-delta rate.
+	const interval = 50 * time.Millisecond
+	logger := &captureLogger{}
+	w := &workload{
+		config: Config{ReportInterval: interval},
+		logger: logger,
+	}
+
+	var counter atomic.Int64
+	// 2 MiB written before the first tick: rate = 2 MiB / 0.05s = 40 MiB/s.
+	counter.Store(2 * 1024 * 1024)
+
+	done := make(chan struct{})
+	reporterDone := make(chan struct{})
+	go func() {
+		w.runReporter(context.Background(), done, time.Now(), &counter)
+		close(reporterDone)
+	}()
+
+	time.Sleep(interval + 20*time.Millisecond)
+	close(done)
+	<-reporterDone
+
+	lines := logger.lines()
+	assert.GreaterOrEqual(t, len(lines), 1, "at least one panel line must be printed")
+
+	first := lines[0]
+	assert.Contains(t, first, "wal-flood: payload-written=2.0MB", "payload-written must be human-readable from formatBytes")
+	assert.Contains(t, first, "rate=40.0MB/s", "rate must be the counter delta over the interval, human-readable")
+	assert.Contains(t, first, "elapsed=", "panel must report elapsed time")
 }

--- a/walflood/walflood_test.go
+++ b/walflood/walflood_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -381,4 +382,339 @@ func Test_runReporter(t *testing.T) {
 	assert.Contains(t, first, "wal-flood: payload-written=2.0MB", "payload-written must be human-readable from formatBytes")
 	assert.Contains(t, first, "rate=40.0MB/s", "rate must be the counter delta over the interval, human-readable")
 	assert.Contains(t, first, "elapsed=", "panel must report elapsed time")
+}
+
+// -----------------------------------------------------------------------------
+// Integration tests (testcontainers, real PostgreSQL via db.TestConninfo).
+//
+// They assert the OBSERVABLE proxies of the workload against a live server. The
+// disk-full / PANIC catastrophe path is deliberately NOT covered here: it is
+// environment-dependent and destructive — a manual stand demo, like slot-bloat.
+// All state waits use bounded condition-polling, never a fixed sleep as the wait
+// mechanism (pg_stat_* is updated asynchronously; a fixed sleep is flaky or slow).
+// -----------------------------------------------------------------------------
+
+func TestWorkload_Run_counterClimbs(t *testing.T) {
+	// With Jobs>1 the shared payload counter climbs across workers; the self-report
+	// panel reflects it. Assert payload-written strictly grows between panels (live DB).
+	logger := &captureLogger{}
+	config := Config{
+		Conninfo:       db.TestConninfo,
+		Rate:           0,
+		Rows:           100,
+		PayloadBytes:   1024,
+		ReportInterval: 100 * time.Millisecond,
+		Jobs:           3,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := NewWorkload(config, logger)
+	assert.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	// Poll for at least two panels whose payload-written has grown.
+	var panels []float64
+	for i := 0; i < 200; i++ {
+		panels = panels[:0]
+		for _, l := range logger.lines() {
+			if strings.Contains(l, "payload-written=") {
+				panels = append(panels, parsePayloadBytes(t, l))
+			}
+		}
+		if len(panels) >= 2 && panels[len(panels)-1] > panels[0] {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	cancel()
+	assert.NoError(t, <-done)
+
+	assert.GreaterOrEqual(t, len(panels), 2, "at least two escalation panels must be printed")
+	assert.Greater(t, panels[len(panels)-1], panels[0], "payload-written must climb across panels")
+}
+
+func TestWorkload_Run_seedRowCountFlatHeap(t *testing.T) {
+	// The payload counter grows during churn while the heap stays flat: count(*)
+	// remains == Rows across the run (only WAL grows, not the table).
+	const rows = 12
+	config := Config{
+		Conninfo:       db.TestConninfo,
+		Rate:           100,
+		Rows:           rows,
+		PayloadBytes:   128,
+		ReportInterval: 100 * time.Millisecond,
+		Jobs:           3,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	defer cancel()
+
+	w, err := NewWorkload(config, log.NewDefaultLogger("error"))
+	assert.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	obs, err := db.Connect(context.Background(), db.TestConninfo)
+	assert.NoError(t, err)
+	defer func() { _ = obs.Close() }()
+
+	// Wait until the seed table appears, then assert flat heap mid-run.
+	var table string
+	for i := 0; i < 50; i++ {
+		table = discoverWalFloodTable(t, obs)
+		if table != "" {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.NotEmpty(t, table, "seed table must appear")
+
+	tableIdent := "\"" + table + "\""
+	assert.Equal(t, rows, countRows(t, obs, tableIdent))
+
+	// Poll n_tup_upd > 0: the churn loop must actually have issued UPDATEs — a flat
+	// heap alone would also pass with zero writes. Stats are async, so poll.
+	var upd int64
+	for i := 0; i < 50; i++ {
+		upd = tupUpd(t, obs, table)
+		if upd > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	assert.Greater(t, upd, int64(0), "the churn loop must have issued UPDATEs against the seed table")
+
+	// Re-check the row count is still Rows (flat heap) after churn has run.
+	assert.Equal(t, rows, countRows(t, obs, tableIdent))
+
+	cancel()
+	assert.NoError(t, <-done)
+}
+
+func TestWorkload_Run_jobsHonored(t *testing.T) {
+	// With Jobs=N, at least N noisia backends are concurrently active mid-run. This is
+	// the central new test vs slot-bloat: it holds INDEPENDENT of the host CPU count
+	// because each worker owns its own db.Connect (Decision 1) — do NOT "simplify" the
+	// engine into a shared pool, whose default max_conns would cap this below Jobs.
+	const jobs = 3
+	config := Config{
+		Conninfo:       db.TestConninfo,
+		Rate:           50,
+		Rows:           100,
+		PayloadBytes:   256,
+		ReportInterval: 200 * time.Millisecond,
+		Jobs:           jobs,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	w, err := NewWorkload(config, log.NewDefaultLogger("error"))
+	assert.NoError(t, err)
+
+	done := make(chan error, 1)
+	go func() { done <- w.Run(ctx) }()
+
+	obs, err := db.Connect(context.Background(), db.TestConninfo)
+	assert.NoError(t, err)
+	defer func() { _ = obs.Close() }()
+
+	// Poll until at least Jobs noisia backends are concurrently active. The observer
+	// conn does not set application_name, so it is not counted.
+	var n int
+	for i := 0; i < 150; i++ {
+		n = countNoisiaBackends(t, obs)
+		if n >= jobs {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	assert.GreaterOrEqual(t, n, jobs, "at least Jobs worker backends must be concurrently active, independent of host CPU")
+
+	cancel()
+	assert.NoError(t, <-done)
+}
+
+func TestWorkload_Run_cleanupOnExit(t *testing.T) {
+	// Graceful exit drops the seed table by default.
+	obs, err := db.Connect(context.Background(), db.TestConninfo)
+	assert.NoError(t, err)
+	defer func() { _ = obs.Close() }()
+	purgeWalFlood(t, obs) // start from a clean slate, independent of test order
+
+	config := Config{
+		Conninfo:       db.TestConninfo,
+		Rate:           50,
+		Rows:           10,
+		PayloadBytes:   64,
+		ReportInterval: 200 * time.Millisecond,
+		Jobs:           2,
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 800*time.Millisecond)
+	defer cancel()
+
+	w, err := NewWorkload(config, log.NewDefaultLogger("error"))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Run(ctx))
+
+	assert.Empty(t, discoverWalFloodTable(t, obs), "seed table must be dropped on graceful exit")
+}
+
+func TestWorkload_cleanup_selfSufficient(t *testing.T) {
+	// cleanup must not depend on any live workload connection: it opens its OWN fresh
+	// connection. Prove it deterministically — manually create a matching table (the name
+	// the workload uses), then invoke cleanup directly with no workload running, and
+	// assert it is gone. Catches a conn-reusing regression every run (ADR-002-2).
+	obs, err := db.Connect(context.Background(), db.TestConninfo)
+	assert.NoError(t, err)
+	defer func() { _ = obs.Close() }()
+	purgeWalFlood(t, obs)
+	defer purgeWalFlood(t, obs)
+
+	base := "noisia_walflood_" + randomSuffix(8)
+	tableIdent := "\"" + base + "\""
+
+	_, _, err = obs.Exec(context.Background(), "CREATE TABLE "+tableIdent+" (id int PRIMARY KEY, payload bytea)")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, discoverWalFloodTable(t, obs), "table must exist before cleanup")
+
+	gw, err := NewWorkload(Config{
+		Conninfo:       db.TestConninfo,
+		Rate:           50,
+		Rows:           5,
+		PayloadBytes:   64,
+		ReportInterval: 200 * time.Millisecond,
+		Jobs:           1,
+	}, log.NewDefaultLogger("error"))
+	assert.NoError(t, err)
+	gw.(*workload).cleanup(tableIdent)
+
+	assert.Empty(t, discoverWalFloodTable(t, obs), "table must be dropped by self-sufficient cleanup")
+}
+
+func TestWorkload_Run_rowsLessThanJobs(t *testing.T) {
+	// Rows < Jobs is rejected by validate() before any worker is spawned (no panic /
+	// deadlock path to the fan-out; Decision 2 removes the empty-tail-range edge).
+	_, err := NewWorkload(Config{
+		Conninfo:       db.TestConninfo,
+		Rate:           0,
+		Rows:           2,
+		PayloadBytes:   64,
+		ReportInterval: 200 * time.Millisecond,
+		Jobs:           3,
+	}, log.NewDefaultLogger("error"))
+	assert.Error(t, err)
+}
+
+// parsePayloadBytes extracts the payload-written value from a panel line and returns
+// it as bytes, so a test can compare growth across panels regardless of unit. Panel
+// shape: "wal-flood: payload-written=<n><unit> rate=...".
+func parsePayloadBytes(t *testing.T, line string) float64 {
+	t.Helper()
+	const marker = "payload-written="
+	i := strings.Index(line, marker)
+	assert.GreaterOrEqual(t, i, 0, "line must contain a payload-written field")
+	s := line[i+len(marker):]
+	if j := strings.IndexByte(s, ' '); j >= 0 {
+		s = s[:j]
+	}
+	s = strings.TrimSuffix(s, "B")
+	mult := 1.0
+	switch {
+	case strings.HasSuffix(s, "K"):
+		mult, s = 1024, strings.TrimSuffix(s, "K")
+	case strings.HasSuffix(s, "M"):
+		mult, s = 1024*1024, strings.TrimSuffix(s, "M")
+	case strings.HasSuffix(s, "G"):
+		mult, s = 1024*1024*1024, strings.TrimSuffix(s, "G")
+	}
+	v, err := strconv.ParseFloat(s, 64)
+	assert.NoError(t, err)
+	return v * mult
+}
+
+// discoverWalFloodTable returns the single noisia_walflood_% table name present in the
+// target DB, or "" if none. Used by integration tests since the suffix is random.
+func discoverWalFloodTable(t *testing.T, conn db.Conn) string {
+	t.Helper()
+	rows, err := conn.Query(context.Background(),
+		"SELECT tablename FROM pg_tables WHERE tablename LIKE 'noisia_walflood_%'")
+	assert.NoError(t, err)
+	defer rows.Close()
+	var name string
+	for rows.Next() {
+		assert.NoError(t, rows.Scan(&name))
+	}
+	assert.NoError(t, rows.Err())
+	return name
+}
+
+// countRows returns count(*) for the given table identifier.
+func countRows(t *testing.T, conn db.Conn, tableIdent string) int {
+	t.Helper()
+	rows, err := conn.Query(context.Background(), "SELECT count(*) FROM "+tableIdent)
+	assert.NoError(t, err)
+	defer rows.Close()
+	var n int
+	for rows.Next() {
+		assert.NoError(t, rows.Scan(&n))
+	}
+	assert.NoError(t, rows.Err())
+	return n
+}
+
+// tupUpd returns n_tup_upd for the given relation from pg_stat_user_tables. Used to
+// prove the churn loop actually wrote (stats are updated asynchronously).
+func tupUpd(t *testing.T, conn db.Conn, relname string) int64 {
+	t.Helper()
+	rows, err := conn.Query(context.Background(),
+		"SELECT coalesce(n_tup_upd, 0) FROM pg_stat_user_tables WHERE relname = $1", relname)
+	assert.NoError(t, err)
+	defer rows.Close()
+	var n int64
+	for rows.Next() {
+		assert.NoError(t, rows.Scan(&n))
+	}
+	assert.NoError(t, rows.Err())
+	return n
+}
+
+// countNoisiaBackends returns the number of backends with application_name='noisia'.
+func countNoisiaBackends(t *testing.T, conn db.Conn) int {
+	t.Helper()
+	rows, err := conn.Query(context.Background(),
+		"SELECT count(*) FROM pg_stat_activity WHERE application_name = 'noisia'")
+	assert.NoError(t, err)
+	defer rows.Close()
+	var n int
+	for rows.Next() {
+		assert.NoError(t, rows.Scan(&n))
+	}
+	assert.NoError(t, rows.Err())
+	return n
+}
+
+// purgeWalFlood drops every leftover noisia_walflood_% table so a test starts from a
+// clean slate, independent of test order. wal-flood has no replication slots to purge.
+func purgeWalFlood(t *testing.T, conn db.Conn) {
+	t.Helper()
+	rows, err := conn.Query(context.Background(),
+		"SELECT tablename FROM pg_tables WHERE tablename LIKE 'noisia_walflood_%'")
+	assert.NoError(t, err)
+	var names []string
+	for rows.Next() {
+		var n string
+		assert.NoError(t, rows.Scan(&n))
+		names = append(names, n)
+	}
+	rows.Close()
+	for _, n := range names {
+		_, _, _ = conn.Exec(context.Background(), "DROP TABLE IF EXISTS \""+n+"\"")
+	}
 }

--- a/walflood/walflood_test.go
+++ b/walflood/walflood_test.go
@@ -1,0 +1,139 @@
+// Copyright 2021 The Noisia Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package walflood
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_validate(t *testing.T) {
+	base := Config{
+		Conninfo:       "host=127.0.0.1 dbname=postgres",
+		Rate:           0,
+		Rows:           1000,
+		PayloadBytes:   8192,
+		ReportInterval: time.Second,
+		Jobs:           4,
+	}
+
+	assert.NoError(t, base.validate(), "valid baseline must pass")
+
+	tests := []struct {
+		name string
+		mut  func(c *Config)
+	}{
+		{"empty conninfo", func(c *Config) { c.Conninfo = "" }},
+		{"negative rate", func(c *Config) { c.Rate = -1 }},
+		{"zero rows", func(c *Config) { c.Rows = 0 }},
+		{"zero payload bytes", func(c *Config) { c.PayloadBytes = 0 }},
+		{"zero report interval", func(c *Config) { c.ReportInterval = 0 }},
+		{"negative report interval", func(c *Config) { c.ReportInterval = -time.Second }},
+		{"zero jobs", func(c *Config) { c.Jobs = 0 }},
+		{"rows less than jobs", func(c *Config) { c.Rows = 2; c.Jobs = 3 }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := base
+			tt.mut(&c)
+			assert.Error(t, c.validate(), "invalid config must be rejected")
+		})
+	}
+}
+
+func Test_partition(t *testing.T) {
+	cases := []struct {
+		rows int
+		jobs uint16
+	}{
+		{1000, 4}, // even split
+		{10, 3},   // rows % jobs != 0 (remainder spread into tail ranges)
+		{5, 5},    // rows == jobs (one id per worker)
+		{100, 1},  // single worker owns the whole range
+		{7, 2},    // odd remainder
+	}
+
+	for _, c := range cases {
+		ranges := partition(c.rows, c.jobs)
+
+		assert.Len(t, ranges, int(c.jobs), "must return exactly Jobs ranges")
+		assert.Equal(t, 1, ranges[0][0], "coverage must start at id 1")
+		assert.Equal(t, c.rows, ranges[len(ranges)-1][1], "coverage must end at id Rows")
+
+		for i, r := range ranges {
+			assert.LessOrEqual(t, r[0], r[1], "range must be non-empty (lo <= hi)")
+			if i > 0 {
+				assert.Equal(t, ranges[i-1][1]+1, r[0],
+					"ranges must be contiguous with no gap or overlap")
+			}
+		}
+	}
+}
+
+func Test_randomSuffix(t *testing.T) {
+	re := regexp.MustCompile(`^[a-z0-9]+$`)
+	s := randomSuffix(8)
+
+	assert.Len(t, s, 8, "suffix must have the requested length")
+	assert.Regexp(t, re, s, "suffix must be an injection-safe identifier")
+}
+
+func Test_sanitize(t *testing.T) {
+	testcases := []struct {
+		name       string
+		err        error
+		suppressed bool
+		want       string // expected output for the non-suppressed (pass-through) cases
+	}{
+		{name: "password token", err: fmt.Errorf("failed: password=SENTINEL_SECRET host=db"), suppressed: true},
+		{name: "host token", err: fmt.Errorf("dial error host=SENTINEL_SECRET"), suppressed: true},
+		{name: "user token", err: fmt.Errorf("auth failed user=SENTINEL_SECRET"), suppressed: true},
+		{name: "dbname token", err: fmt.Errorf("connect failed dbname=SENTINEL_SECRET"), suppressed: true},
+		{name: "database token", err: fmt.Errorf("dial error database=SENTINEL_SECRET"), suppressed: true},
+		{name: "sslmode token", err: fmt.Errorf("tls error sslmode=SENTINEL_SECRET"), suppressed: true},
+		{name: "url form", err: fmt.Errorf("failed: postgres://user:SENTINEL_SECRET@db/noisia"), suppressed: true},
+		// seed/cleanup error paths: a wrapped DSN fragment must still collapse.
+		{name: "seed error", err: fmt.Errorf("seed table failed: dial tcp host=SENTINEL_SECRET refused"), suppressed: true},
+		{name: "cleanup drop error", err: fmt.Errorf("DROP TABLE failed: password=SENTINEL_SECRET timeout"), suppressed: true},
+		{name: "benign", err: fmt.Errorf("server closed the connection unexpectedly"), suppressed: false, want: "server closed the connection unexpectedly"},
+		{name: "nil", err: nil, suppressed: false, want: ""},
+	}
+
+	for _, tc := range testcases {
+		got := sanitize(tc.err)
+		assert.NotContains(t, got, "SENTINEL_SECRET", tc.name)
+		if tc.suppressed {
+			assert.Equal(t, "connection error (details suppressed)", got, tc.name)
+		} else {
+			assert.Equal(t, tc.want, got, tc.name)
+		}
+	}
+}
+
+func Test_formatBytes(t *testing.T) {
+	testcases := []struct {
+		n    int64
+		want string
+	}{
+		{n: 0, want: "0B"},                      // zero
+		{n: 42, want: "42B"},                    // within B range
+		{n: 1023, want: "1023B"},                // just below the KB boundary
+		{n: 1024, want: "1.0KB"},                // exactly the KB boundary
+		{n: 512 * 1024, want: "512.0KB"},        // within KB range
+		{n: 1024 * 1024, want: "1.0MB"},         // exactly the MB boundary
+		{n: 180 * 1024 * 1024, want: "180.0MB"}, // within MB range
+		{n: 1024 * 1024 * 1024, want: "1.0GB"},  // exactly the GB boundary
+		{n: 4509715660, want: "4.2GB"},          // within GB range
+	}
+
+	for _, tc := range testcases {
+		assert.Equal(t, tc.want, formatBytes(tc.n))
+	}
+}

--- a/walflood/walflood_test.go
+++ b/walflood/walflood_test.go
@@ -55,6 +55,7 @@ func Test_partition(t *testing.T) {
 	}{
 		{1000, 4}, // even split
 		{10, 3},   // rows % jobs != 0 (remainder spread into tail ranges)
+		{11, 3},   // larger remainder (2) lands in the tail ranges
 		{5, 5},    // rows == jobs (one id per worker)
 		{100, 1},  // single worker owns the whole range
 		{7, 2},    // odd remainder
@@ -79,10 +80,13 @@ func Test_partition(t *testing.T) {
 
 func Test_randomSuffix(t *testing.T) {
 	re := regexp.MustCompile(`^[a-z0-9]+$`)
-	s := randomSuffix(8)
 
-	assert.Len(t, s, 8, "suffix must have the requested length")
-	assert.Regexp(t, re, s, "suffix must be an injection-safe identifier")
+	// Sample repeatedly: the charset guarantee must hold for every draw, not one.
+	for i := 0; i < 100; i++ {
+		s := randomSuffix(8)
+		assert.Len(t, s, 8, "suffix must have the requested length")
+		assert.Regexp(t, re, s, "suffix must be an injection-safe identifier")
+	}
 }
 
 func Test_sanitize(t *testing.T) {

--- a/walflood/walflood_test.go
+++ b/walflood/walflood_test.go
@@ -441,6 +441,12 @@ func TestWorkload_Run_seedRowCountFlatHeap(t *testing.T) {
 	// The payload counter grows during churn while the heap stays flat: count(*)
 	// remains == Rows across the run (only WAL grows, not the table).
 	const rows = 12
+
+	obs, err := db.Connect(context.Background(), db.TestConninfo)
+	assert.NoError(t, err)
+	defer func() { _ = obs.Close() }()
+	purgeWalFlood(t, obs) // clean slate so discover cannot pick up an orphan table
+
 	config := Config{
 		Conninfo:       db.TestConninfo,
 		Rate:           100,
@@ -450,7 +456,9 @@ func TestWorkload_Run_seedRowCountFlatHeap(t *testing.T) {
 		Jobs:           3,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1500*time.Millisecond)
+	// Cancel explicitly after the assertions (not a fixed deadline) so the workload
+	// cannot time out and drop the table while the observer is still polling.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	w, err := NewWorkload(config, log.NewDefaultLogger("error"))
@@ -458,10 +466,6 @@ func TestWorkload_Run_seedRowCountFlatHeap(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() { done <- w.Run(ctx) }()
-
-	obs, err := db.Connect(context.Background(), db.TestConninfo)
-	assert.NoError(t, err)
-	defer func() { _ = obs.Close() }()
 
 	// Wait until the seed table appears, then assert flat heap mid-run.
 	var table string
@@ -647,12 +651,20 @@ func discoverWalFloodTable(t *testing.T, conn db.Conn) string {
 		"SELECT tablename FROM pg_tables WHERE tablename LIKE 'noisia_walflood_%'")
 	assert.NoError(t, err)
 	defer rows.Close()
-	var name string
+	var names []string
 	for rows.Next() {
+		var name string
 		assert.NoError(t, rows.Scan(&name))
+		names = append(names, name)
 	}
 	assert.NoError(t, rows.Err())
-	return name
+	// At most one wal-flood table should exist at a time; more than one means a prior
+	// test orphaned its table, which would mask a real cleanup regression.
+	assert.LessOrEqual(t, len(names), 1, "at most one wal-flood table should exist at a time")
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
 }
 
 // countRows returns count(*) for the given table identifier.

--- a/walflood/walflood_test.go
+++ b/walflood/walflood_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -200,8 +201,9 @@ func (f *fakeConn) Close() error { return nil }
 
 func Test_runChurn_firstExecError(t *testing.T) {
 	// The first Exec error with the shared counter still at 0 is a setup defect and is
-	// returned as an init error, never masquerading as a climax.
-	conn := &fakeConn{execErr: fmt.Errorf("permission denied"), execOKBefore: 0}
+	// returned as an init error, never masquerading as a climax. The returned error must
+	// also be sanitized — a DSN-carrying pgx error must not leak through.
+	conn := &fakeConn{execErr: fmt.Errorf("dial tcp failed host=SENTINEL_SECRET refused"), execOKBefore: 0}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
@@ -211,6 +213,7 @@ func Test_runChurn_firstExecError(t *testing.T) {
 
 	err := runChurn(ctx, conn, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 5, &counter)
 	assert.Error(t, err)
+	assert.NotContains(t, err.Error(), "SENTINEL_SECRET", "init error must be sanitized")
 	assert.Equal(t, int64(0), counter.Load())
 }
 
@@ -222,13 +225,16 @@ func Test_runChurn_climaxAfterSuccess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
+	logger := &captureLogger{}
 	var counter atomic.Int64
 	config := Config{Conninfo: "x", Rate: 0, Rows: 5, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 1}
 
-	err := runChurn(ctx, conn, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 5, &counter)
+	err := runChurn(ctx, conn, logger, config, "UPDATE t SET payload=$1 WHERE id=$2", 1, 5, &counter)
 	assert.NoError(t, err)
 	// 3 successful UPDATEs × 8 bytes.
 	assert.Equal(t, int64(24), counter.Load())
+	// The climax side-effect (explicit in the TDD anchor) must actually be logged.
+	assert.Contains(t, strings.Join(logger.lines(), "\n"), "connection lost", "climax line must be logged")
 }
 
 func Test_runChurn_ctxDoneClean(t *testing.T) {
@@ -278,20 +284,20 @@ func Test_runChurn_twoWorkersConcurrentFirstFailure(t *testing.T) {
 
 func Test_runChurn_churnsWithinRange(t *testing.T) {
 	// A worker must only UPDATE ids inside its disjoint [lo, hi] sub-range (the
-	// anti-self-defeat guarantee), cycling within the range.
-	rec := &recordingConn{}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	// anti-self-defeat guarantee), cycling within the range. Bounded by iteration
+	// count (not wall-clock): the conn cancels ctx after stopAfter Execs.
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+	rec := &recordingConn{stopAfter: 50, cancel: cancel}
 
 	var counter atomic.Int64
 	config := Config{Conninfo: "x", Rate: 0, Rows: 10, PayloadBytes: 8, ReportInterval: time.Second, Jobs: 2}
 
-	// Worker owns ids 6..10.
+	// Worker owns ids 6..10; 50 Execs over a 5-wide range cover every id at least once.
 	_ = runChurn(ctx, rec, log.NewDefaultLogger("error"), config, "UPDATE t SET payload=$1 WHERE id=$2", 6, 10, &counter)
 
 	ids := rec.seenIDs()
-	assert.NotEmpty(t, ids, "worker must have issued at least one UPDATE")
+	assert.Len(t, ids, 5, "worker must cover exactly its 5-id range")
 	for id := range ids {
 		assert.GreaterOrEqual(t, id, 6, "id must not fall below the worker's range")
 		assert.LessOrEqual(t, id, 10, "id must not exceed the worker's range")
@@ -299,10 +305,14 @@ func Test_runChurn_churnsWithinRange(t *testing.T) {
 }
 
 // recordingConn is a db.Conn double that records the id bind argument of every UPDATE
-// so a test can assert a worker stays within its disjoint range.
+// so a test can assert a worker stays within its disjoint range. After stopAfter Execs
+// it cancels the context, bounding the rate.Inf churn loop without relying on wall-clock.
 type recordingConn struct {
-	mu  sync.Mutex
-	ids map[int]struct{}
+	mu        sync.Mutex
+	ids       map[int]struct{}
+	calls     int
+	stopAfter int
+	cancel    context.CancelFunc
 }
 
 func (c *recordingConn) Begin(ctx context.Context) (db.Tx, error) { panic("not implemented") }
@@ -316,6 +326,10 @@ func (c *recordingConn) Exec(ctx context.Context, sql string, args ...interface{
 		if id, ok := args[1].(int); ok {
 			c.ids[id] = struct{}{}
 		}
+	}
+	c.calls++
+	if c.stopAfter > 0 && c.calls >= c.stopAfter && c.cancel != nil {
+		c.cancel()
 	}
 	return 0, "UPDATE", nil
 }


### PR DESCRIPTION
## What

New `wal-flood` workload: floods WAL on a primary PostgreSQL by raw write rate. It seeds one
fixed-size table and fans out `--jobs` long-lived `UPDATE`-churn workers over **disjoint** id
ranges (no replication slot), each on its own connection, sharing one atomic payload counter and a
self-report escalation panel. The visible-activity counterpart to `slot-bloat`.

Closes the `wal-flood` backlog item (Priority 2 — Disk → full).

## Honest contract

WAL pressure and — with a standby attached — replication lag are **reliable**. Escalation to
disk-full/PANIC is **environment-dependent, not guaranteed** (unlike `slot-bloat`'s deterministic
retention): on capable I/O the WAL rate plateaus. README/docs state this explicitly with a
disk-full condition checklist and recommended demo parameters.

## Design

- **Per-worker `db.Connect`** (not a shared pool) — guarantees `--jobs` concurrent backends
  regardless of the pgxpool default `max_conns`.
- **Disjoint id ranges** over one seed table — avoids row-lock self-throttling; `validate()`
  requires `rows >= jobs`.
- **Single shared atomic counter**; init-vs-climax judged on it.
- **Cleanup on a fresh `context.Background()`** connection (ADR-002-2).
- **Self-report only** — `payload-written`, no server polling (ADR-002-3); noisia does not measure
  replication lag.
- Reuses the global `--jobs` flag (like `idlexacts`/`deadlocks`); no per-workload jobs flag.

## CLI

`--wal-flood[.rate|.rows|.payload-bytes|.report-interval]` (env `NOISIA_WAL_FLOOD*`), parallelism
from the global `--jobs`. No `REPLICATION` privilege required.

## Tests

- 11 unit tests (validate, partition, churn branches incl. concurrent first-failure, reporter,
  sanitize no-leak) on `fakeConn`/`recordingConn`/`captureLogger`.
- 6 testcontainers integration tests: counter climbs, flat heap + `n_tup_upd>0`, `--jobs` honored
  (≥N backends, independent of host CPU), self-sufficient cleanup, `rows<jobs` rejected.
- `make lint` clean; `make test` green; walflood 90.6% coverage. The disk-full catastrophe path is
  intentionally out of CI (environment-dependent, destructive — a manual stand demo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)