### PR TITLE
feat: EXECUTE each prepared statement in backend-killer to cache the generic plan

### DIFF
--- a/backendkiller/backendkiller.go
+++ b/backendkiller/backendkiller.go
@@ -7,10 +7,13 @@
 //
 // A single dedicated connection (not a pool) issues, in a single-threaded
 // rate-limited loop, unique literal server-side prepared statements of the form
-// "PREPARE noisia_bk_<i> AS SELECT 0 AS c0, 1 AS c1, …". Each PREPARE adds a
-// cached plan to the backend's plan cache; the statements are never DEALLOCATEd,
-// so the plan cache (and the backend's RSS) grows without bound. Eventually the
-// OOM killer reaps the backend and the postmaster restarts the whole instance.
+// "PREPARE noisia_bk_<i> AS SELECT 0 AS c0, 1 AS c1, …" and immediately EXECUTEs
+// each one once. PREPARE caches the statement's parse/rewrite tree; the first
+// EXECUTE builds and caches its generic plan as well, so each pair grows the
+// backend's plan cache (and RSS) faster than PREPARE alone. The statements are
+// never DEALLOCATEd, so the plan cache (and the backend's RSS) grows without
+// bound. Eventually the OOM killer reaps the backend and the postmaster restarts
+// the whole instance.
 //
 // The workload self-reports: it keeps an in-process counter of created statements
 // and prints an escalation panel every report-interval via logger.Infof. When its
@@ -157,15 +160,17 @@ func (w *workload) runReporter(ctx context.Context, done <-chan struct{}, start 
 	}
 }
 
-// runLoop is the single-threaded rate-limited PREPARE loop. It owns the Conn:
-// it issues each PREPARE and, when enabled, performs the periodic own-backend
-// memory read. It increments counter for each successful statement and publishes
-// the memory estimate via mem.
+// runLoop is the single-threaded rate-limited PREPARE+EXECUTE loop. It owns the
+// Conn: each iteration issues a PREPARE then EXECUTEs it once and, when enabled,
+// performs the periodic own-backend memory read. It increments counter once per
+// completed PREPARE+EXECUTE pair (the pair is one statement; EXECUTE is a memory
+// amplifier, not a separate metric) and publishes the memory estimate via mem.
 //
 // Returns nil on a clean ctx stop. On a connection loss after at least one
-// successful PREPARE (counter>0) while the context is still live, it logs the
-// climax line and returns nil. The first Exec error (counter==0) is returned as
-// an init error, so a broken builder cannot masquerade as a successful OOM event.
+// completed pair (counter>0) while the context is still live, it logs the climax
+// line and returns nil. An Exec error on the very first statement, in either the
+// PREPARE or the EXECUTE phase (counter==0), is returned as an init error, so a
+// broken builder cannot masquerade as a successful OOM event.
 func runLoop(ctx context.Context, conn db.Conn, logger log.Logger, config Config, counter, mem *atomic.Int64) error {
 	lim := rate.Limit(config.Rate)
 	if config.Rate == 0 {
@@ -178,28 +183,49 @@ func runLoop(ctx context.Context, conn db.Conn, logger log.Logger, config Config
 	var lastMemoryRead time.Time
 	var memWarned bool
 
+	// fail maps an Exec error (from either the PREPARE or the EXECUTE) to runLoop's
+	// return value: nil on a clean ctx stop, nil after logging the climax once at
+	// least one statement landed (the target was likely OOM-restarted), or an init
+	// error when the very first statement failed (a setup/builder defect, never a
+	// climax). Both phases share this because an OOM can reap the backend at either.
+	fail := func(err error) error {
+		// A clean ctx stop must not be reported as a failure.
+		if ctx.Err() != nil {
+			return nil
+		}
+
+		if counter.Load() > 0 {
+			logger.Infof("backend-killer: connection lost after %s, %d statements issued — target likely OOM-restarted", time.Since(start).Truncate(time.Second), counter.Load())
+			return nil
+		}
+
+		return fmt.Errorf("issue prepared statement failed: %s", sanitize(err))
+	}
+
 	for {
 		if limiter.Allow() {
 			q := buildPrepare(i, config.PlanSize)
+			id := i
 			i++
 
-			_, _, err := conn.Exec(ctx, q)
-			if err != nil {
-				// A clean ctx stop must not be reported as a failure.
-				if ctx.Err() != nil {
-					return nil
-				}
-
-				if counter.Load() > 0 {
-					logger.Infof("backend-killer: connection lost after %s, %d statements issued — target likely OOM-restarted", time.Since(start).Truncate(time.Second), counter.Load())
-					return nil
-				}
-
-				// First Exec failed with no prior success: this is a setup/builder
-				// defect, not a successful OOM event.
-				return fmt.Errorf("issue prepared statement failed: %s", sanitize(err))
+			if _, _, err := conn.Exec(ctx, q); err != nil {
+				return fail(err)
 			}
 
+			// EXECUTE the freshly prepared statement once. PREPARE caches only the
+			// parse/rewrite tree; the first EXECUTE builds and caches the generic
+			// plan as well (these statements have no bind args, so the generic plan
+			// is used immediately). That roughly doubles the per-statement memory and
+			// reaches OOM sooner. The result row is discarded.
+			if _, _, err := conn.Exec(ctx, buildExecute(id)); err != nil {
+				return fail(err)
+			}
+
+			// Count the statement only once its EXECUTE has also landed: the generic
+			// plan (the bulk of the leaked memory) is cached only after EXECUTE, and
+			// the counter==0 init-error guard in fail() must reject a first-EXECUTE
+			// builder defect just as it rejects a first-PREPARE one. counter therefore
+			// tracks completed PREPARE+EXECUTE pairs.
 			counter.Add(1)
 
 			// Optional own-backend memory read on the report cadence. Performed by
@@ -242,6 +268,13 @@ func buildPrepare(i int64, planSize int) string {
 		fmt.Fprintf(&b, "%d AS c%d", j, j)
 	}
 	return b.String()
+}
+
+// buildExecute builds the EXECUTE statement for the prepared statement id created
+// by buildPrepare: "EXECUTE noisia_bk_<i>". The statement takes no parameters, so
+// there is no bind argument and no injection surface.
+func buildExecute(i int64) string {
+	return fmt.Sprintf("EXECUTE noisia_bk_%d", i)
 }
 
 // readBackendMemory reads the total bytes used by the current backend's memory

--- a/backendkiller/backendkiller_test.go
+++ b/backendkiller/backendkiller_test.go
@@ -69,6 +69,21 @@ func Test_buildPrepare(t *testing.T) {
 	assert.Regexp(t, `^PREPARE noisia_bk_\d+ AS SELECT (\d+ AS c\d+)(, \d+ AS c\d+)*$`, q0)
 }
 
+func Test_buildExecute(t *testing.T) {
+	e0 := buildExecute(0)
+	e7 := buildExecute(7)
+
+	// Statement name must match the one PREPARE created for the same id and be
+	// unique per id.
+	assert.Equal(t, "EXECUTE noisia_bk_0", e0)
+	assert.Equal(t, "EXECUTE noisia_bk_7", e7)
+	assert.NotEqual(t, e0, e7)
+
+	// Composed solely of the prefix and an int id — no bind args, no injection
+	// surface — including a large id where %d formatting could differ.
+	assert.Regexp(t, `^EXECUTE noisia_bk_\d+$`, buildExecute(1_000_000))
+}
+
 func Test_sanitize(t *testing.T) {
 	testcases := []struct {
 		name       string
@@ -195,14 +210,16 @@ func Test_runLoop_monotonicGrowth(t *testing.T) {
 // guard branches in runLoop without a real database. Only Exec is invoked
 // (ShowMemory is false in these tests, so Query is never called).
 type fakeConn struct {
-	execErr      error // returned once execOKBefore successful Execs have happened
-	execOKBefore int   // number of successful Execs before execErr is returned
-	calls        int
+	execErr      error    // returned once execOKBefore successful Execs have happened
+	execOKBefore int      // number of successful Execs before execErr is returned
+	calls        int      // total Exec calls (PREPARE + EXECUTE)
+	sqls         []string // every SQL string passed to Exec, in order
 }
 
 func (f *fakeConn) Begin(ctx context.Context) (db.Tx, error) { panic("not implemented") }
 func (f *fakeConn) Exec(ctx context.Context, sql string, args ...interface{}) (int64, string, error) {
 	f.calls++
+	f.sqls = append(f.sqls, sql)
 	if f.calls > f.execOKBefore {
 		return 0, "", f.execErr
 	}
@@ -213,9 +230,32 @@ func (f *fakeConn) Query(ctx context.Context, sql string, args ...interface{}) (
 }
 func (f *fakeConn) Close() error { return nil }
 
+func Test_runLoop_executeFollowsPrepare(t *testing.T) {
+	// Each loop iteration issues PREPARE then EXECUTE for the same statement id.
+	// Stop after the second PREPARE so the recorded SQL is deterministic.
+	conn := &fakeConn{execErr: fmt.Errorf("connection reset by peer"), execOKBefore: 2}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var counter, mem atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, PlanSize: 2, ReportInterval: time.Second}
+
+	err := runLoop(ctx, conn, log.NewDefaultLogger("error"), config, &counter, &mem)
+	assert.NoError(t, err)
+
+	// PREPARE for id 0, then EXECUTE for the same id 0, then PREPARE for id 1 (which fails).
+	assert.True(t, strings.HasPrefix(conn.sqls[0], "PREPARE noisia_bk_0 "))
+	assert.Equal(t, "EXECUTE noisia_bk_0", conn.sqls[1])
+	assert.True(t, strings.HasPrefix(conn.sqls[2], "PREPARE noisia_bk_1 "))
+}
+
 func Test_runLoop_climaxAfterSuccess(t *testing.T) {
 	// Decision 5: an Exec error under a live ctx with counter>0 is the climax —
-	// runLoop logs the climax line and returns nil.
+	// runLoop logs the climax line and returns nil. Here the error lands on the
+	// EXECUTE of the second statement: PREPARE(0) ok, EXECUTE(0) ok, PREPARE(1) ok,
+	// EXECUTE(1) fails. counter tracks completed PREPARE+EXECUTE pairs, so the first
+	// pair leaves it at 1.
 	conn := &fakeConn{execErr: fmt.Errorf("connection reset by peer"), execOKBefore: 3}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -226,7 +266,28 @@ func Test_runLoop_climaxAfterSuccess(t *testing.T) {
 
 	err := runLoop(ctx, conn, log.NewDefaultLogger("error"), config, &counter, &mem)
 	assert.NoError(t, err)
-	assert.Equal(t, int64(3), counter.Load())
+	assert.Equal(t, int64(1), counter.Load())
+	// The failing call was an EXECUTE — an OOM during plan caching is a valid climax.
+	assert.True(t, strings.HasPrefix(conn.sqls[len(conn.sqls)-1], "EXECUTE "))
+}
+
+func Test_runLoop_firstExecuteError(t *testing.T) {
+	// Mirror of Test_runLoop_firstExecError on the EXECUTE phase: PREPARE(0) ok,
+	// then EXECUTE(0) fails with no completed pair yet (counter==0). A first-EXECUTE
+	// builder defect must surface as an init error, never as a climax.
+	conn := &fakeConn{execErr: fmt.Errorf("prepared statement does not exist"), execOKBefore: 1}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var counter, mem atomic.Int64
+	config := Config{Conninfo: "x", Rate: 0, PlanSize: 2, ReportInterval: time.Second}
+
+	err := runLoop(ctx, conn, log.NewDefaultLogger("error"), config, &counter, &mem)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), counter.Load())
+	// The failure was on the EXECUTE, not the PREPARE.
+	assert.True(t, strings.HasPrefix(conn.sqls[len(conn.sqls)-1], "EXECUTE "))
 }
 
 func Test_runLoop_firstExecError(t *testing.T) {

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -48,11 +48,12 @@ Each entry below is sized to be expanded into a user-spec.
 - **Status:** implemented (prepared-statement / plan-cache leak variant). Verified end-to-end on a
   stand: cgroup `CONSTRAINT_MEMCG` OOM of the backend → instance restart → climax line logged.
 - **Follow-up ideas:**
-  - Optionally `EXECUTE` each prepared statement once: `PREPARE` caches only the query tree, while the
-    generic plan is built/cached on first `EXECUTE` — executing would grow backend memory faster and
-    reach OOM sooner without needing a tightly capped stand.
-  - Document/observe that with swap enabled the approach degrades (panel rate → `0/s`) instead of a
-    prompt OOM (already captured in the README demo tips).
+  - ~~Optionally `EXECUTE` each prepared statement once~~ — **done:** every `PREPARE` is now
+    unconditionally followed by one `EXECUTE` (no flag). `PREPARE` caches only the parse/rewrite tree;
+    the first `EXECUTE` builds and caches the generic plan too (these statements take no bind args, so
+    the generic plan is used immediately), roughly doubling per-statement memory and reaching OOM sooner.
+  - ~~Document/observe that with swap enabled the approach degrades (panel rate → `0/s`) instead of a
+    prompt OOM~~ — **done:** captured in `docs/workloads/backend-killer.md` ("Disable swap" tip).
 
 ## Priority 2 — Disk → full
 

--- a/docs/workloads/backend-killer.md
+++ b/docs/workloads/backend-killer.md
@@ -2,8 +2,9 @@
 
 How to drive a reliable `backend-killer` demo and tune the pressure so the OOM kill (and instance restart) happens predictably.
 
-`backend-killer` drives a single backend toward OOM by leaking prepared statements. How fast you reach
-the OOM kill (and the instance restart) depends on the stand:
+`backend-killer` drives a single backend toward OOM by leaking prepared statements — each one is
+`PREPARE`d and then `EXECUTE`d once, so the backend caches both the parse tree and the generic plan.
+How fast you reach the OOM kill (and the instance restart) depends on the stand:
 
 - **Cap the backend's memory** so OOM is reached in minutes, not hours: a systemd `MemoryMax=` on the
   PostgreSQL service (you then get a cgroup/`CONSTRAINT_MEMCG` OOM), a container `--memory=...` limit, or


### PR DESCRIPTION
## What

Every `PREPARE` in the `backend-killer` plan-cache-leak loop is now unconditionally followed by one `EXECUTE` of the same statement (no flag).

## Why

`PREPARE` caches only the parse/rewrite tree; the **first `EXECUTE`** builds and caches the **generic plan** too (these statements take no bind args, so the generic plan is used immediately). This roughly doubles per-statement backend memory and reaches OOM sooner — without needing a tightly capped stand. Closes both backend-killer follow-ups in `docs/BACKLOG.md` (the swap-degradation note was already documented in the demo guide).

## Notes

- `counter` is incremented only **after** a successful `EXECUTE`, so it tracks completed `PREPARE+EXECUTE` pairs. This keeps the `counter==0` init-error guard honest: a builder defect on the first statement's `EXECUTE` surfaces as an init error, not a fake OOM climax.
- `PREPARE` and `EXECUTE` error handling share one `fail()` closure (clean stop → nil, climax when `counter>0`, else sanitized init error — no DSN leak).

## Tests

New `Test_buildExecute`, `Test_runLoop_executeFollowsPrepare`, `Test_runLoop_firstExecuteError`; updated `Test_runLoop_climaxAfterSuccess`. `go test -race`, `go vet`, `gofmt`, `golangci-lint v2.12.2`, `go build ./...` — all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)